### PR TITLE
Changes required for LWJGL 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# ignore editors
+.vscode
+.idea
+*.iml
+
+# mac ignoreable
+.DS_Store
+
+bin

--- a/shaders/pipe.frag
+++ b/shaders/pipe.frag
@@ -14,12 +14,16 @@ uniform int top;
 
 void main()
 {
+	vec2 tc_temp = fs_in.tc;
+
 	if (top == 1)
-		fs_in.tc.y = 1.0 - fs_in.tc.y;
+		tc_temp = 1.0 - fs_in.tc.y;
 		
-	color = texture(tex, fs_in.tc);
+	color = texture(tex, tc_temp);
+
 	if (color.w < 1.0)
 		discard;
+
 	color *= 2.0 / (length(bird - fs_in.position.xy) + 1.5) + 0.5;
 	color.w = 1.0;
 }

--- a/shaders/pipe.frag
+++ b/shaders/pipe.frag
@@ -17,7 +17,7 @@ void main()
 	vec2 tc_temp = fs_in.tc;
 
 	if (top == 1)
-		tc_temp = 1.0 - fs_in.tc.y;
+		tc_temp.y = 1.0 - fs_in.tc.y;
 		
 	color = texture(tex, tc_temp);
 

--- a/src/com/thecherno/flappy/Main.java
+++ b/src/com/thecherno/flappy/Main.java
@@ -1,14 +1,12 @@
 package com.thecherno.flappy;
 
 import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.opengl.GL.*;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL13.*;
 import static org.lwjgl.system.MemoryUtil.*;
 
-import java.nio.ByteBuffer;
-
-import org.lwjgl.glfw.GLFWvidmode;
-import org.lwjgl.opengl.GLContext;
+import org.lwjgl.glfw.GLFWVidMode;
 
 import com.thecherno.flappy.graphics.Shader;
 import com.thecherno.flappy.input.Input;
@@ -34,7 +32,7 @@ public class Main implements Runnable {
 	}
 	
 	private void init() {
-		if (glfwInit() != GL_TRUE) {
+		if (!glfwInit()) {
 			System.err.println("Could not initialize GLFW!");
 			return;
 		}
@@ -46,14 +44,14 @@ public class Main implements Runnable {
 			return;
 		}
 		
-		ByteBuffer vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
-		glfwSetWindowPos(window, (GLFWvidmode.width(vidmode) - width) / 2, (GLFWvidmode.height(vidmode) - height) / 2);
+		GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+		glfwSetWindowPos(window, (vidmode.width() - width) / 2, (vidmode.height() - height) / 2);
 		
 		glfwSetKeyCallback(window, new Input());
 		
 		glfwMakeContextCurrent(window);
 		glfwShowWindow(window);
-		GLContext.createFromCurrent();
+		createCapabilities();
 		
  		glEnable(GL_DEPTH_TEST);
 		glActiveTexture(GL_TEXTURE1);
@@ -101,7 +99,7 @@ public class Main implements Runnable {
 				updates = 0;
 				frames = 0;
 			}
-			if (glfwWindowShouldClose(window) == GL_TRUE)
+			if (glfwWindowShouldClose(window))
 				running = false;
 		}
 		

--- a/src/com/thecherno/flappy/graphics/Shader.java
+++ b/src/com/thecherno/flappy/graphics/Shader.java
@@ -66,7 +66,7 @@ public class Shader {
 	
 	public void setUniformMat4f(String name, Matrix4f matrix) {
 		if (!enabled) enable();
-		glUniformMatrix4(getUniform(name), false, matrix.toFloatBuffer());
+		glUniformMatrix4fv(getUniform(name), false, matrix.toFloatBuffer());
 	}
 	
 	public void enable() {

--- a/src/com/thecherno/flappy/input/Input.java
+++ b/src/com/thecherno/flappy/input/Input.java
@@ -3,9 +3,11 @@ package com.thecherno.flappy.input;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWKeyCallback;
 
+import static org.lwjgl.glfw.GLFW.*;
+
 public class Input extends GLFWKeyCallback {
 	
-	public static boolean[] keys = new boolean[65536];
+	public static boolean[] keys = new boolean[GLFW_KEY_LAST];
 
 	public void invoke(long window, int key, int scancode, int action, int mods) {
 		keys[key] = action != GLFW.GLFW_RELEASE; 


### PR DESCRIPTION
For the current version of LWJGL 3.2.1, I found the following changes are necessary to run this very satisfying Flappy game clone tutorial. Thank you for making this tutorial.